### PR TITLE
1 dark theme on hacker news app

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -126,4 +126,15 @@ a {
     }
   }
 }
+
+/* Dark mode styles */
+.dark-mode body {
+  background-color: #020420;
+  color: #F4F4F5;
+}
+
+.dark-mode a {
+  color: #F4F4F5;
+}
+
 </style>

--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -1,5 +1,14 @@
 <script setup lang="ts">
 import { feedsInfo } from '~~/utils/api'
+
+import { ref } from 'vue'
+
+const isDarkMode = ref(false)
+
+function toggleSwitch() {
+  isDarkMode.value = !isDarkMode.value
+  document.documentElement.classList.toggle('dark-mode', isDarkMode.value)
+}
 </script>
 
 <template>

--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -32,7 +32,7 @@ import { feedsInfo } from '~~/utils/api'
       >
         {{ list.title }}
       </NuxtLink>
-      <span class="github">
+      <span class="github" style="margin-right: 10px;">
         <a
           href="https://github.com/nuxt/hackernews"
           target="_blank"
@@ -41,6 +41,14 @@ import { feedsInfo } from '~~/utils/api'
           Open on GitHub
         </a>
       </span>
+
+      <span @click="toggleSwitch" style="cursor: pointer;">
+        <svg width="24px" height="24px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path d="M12 16C14.2091 16 16 14.2091 16 12C16 9.79086 14.2091 8 12 8V16Z" fill="#FFFFFF"/>
+          <path fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2ZM12 4V8C9.79086 8 8 9.79086 8 12C8 14.2091 9.79086 16 12 16V20C16.4183 20 20 16.4183 20 12C20 7.58172 16.4183 4 12 4Z" fill="#FFFFFF"/>
+        </svg>
+      </span>
+      
     </nav>
   </header>
 </template>

--- a/app/components/ItemListNav.vue
+++ b/app/components/ItemListNav.vue
@@ -59,4 +59,24 @@ const hasMore = computed(() => props.page < props.maxPage)
     text-align: center;
   }
 }
+
+/* Dark mode styles */
+.dark-mode .news-list-nav, .dark-mode .news-list {
+  background-color: #2e2e2e;
+}
+
+.dark-mode .news-list-nav {
+  & a {
+    color: #ccc;
+  }
+
+  .disabled {
+    opacity: 0.5;
+  }
+
+  .page {
+    color: #ccc;
+  }
+}
+
 </style>

--- a/app/components/PostComment.vue
+++ b/app/components/PostComment.vue
@@ -103,4 +103,44 @@ function pluralize(n: number) {
     }
   }
 }
+
+/* Dark mode styles */
+.dark-mode .comment {
+  border-top: 1px solid #444;
+
+  .by {
+    color: #ccc;
+
+    & a {
+      color: #ccc;
+    }
+  }
+
+  .text {
+    color: #ccc;
+
+    & a:hover {
+      color: #00C48D;
+    }
+
+    & pre {
+      background-color: #333;
+      color: #ccc;
+    }
+  }
+
+  .toggle {
+    background-color: #333;
+    color: #ccc;
+
+    & a {
+      color: #00C48D;
+    }
+
+    &.open {
+      background-color: transparent;
+    }
+  }
+}
+
 </style>

--- a/app/components/PostItem.vue
+++ b/app/components/PostItem.vue
@@ -86,4 +86,27 @@ defineProps<{
     }
   }
 }
+
+/* Dark mode styles */
+.dark-mode .news-item {
+  background-color: #2e2e2e;
+  border-bottom: 1px solid #444;
+
+  .score {
+    color: #00C48D;
+  }
+
+  .meta, .host {
+    color: #ccc;
+
+    & a {
+      color: #ccc;
+
+      &:hover {
+        color: #00C48D;
+      }
+    }
+  }
+}
+
 </style>

--- a/app/pages/[feed]/[page].vue
+++ b/app/pages/[feed]/[page].vue
@@ -139,4 +139,10 @@ watch(page, to => pageChanged(to))
     margin: 10px 0;
   }
 }
+
+/* Dark mode styles */
+.dark-mode .news-list {
+  background-color: #2e2e2e;
+}
+
 </style>

--- a/app/pages/item/[id].vue
+++ b/app/pages/item/[id].vue
@@ -123,4 +123,30 @@ useHead({
     }
   }
 }
+
+/* Dark mode styles */
+.dark-mode .item-view-header {
+  background-color: #2e2e2e;
+  box-shadow: 0 1px 2px rgba(255, 255, 255, 0.1);
+
+  & h1 {
+    color: #F4F4F5;
+  }
+
+  .host, .meta, .meta a {
+    color: #ccc;
+  }
+  .meta a:hover {
+    color: #00C48D;
+  }
+}
+
+.dark-mode .item-view-comments {
+  background-color: #2e2e2e;
+}
+
+.dark-mode .item-view-comments-header {
+  color: #F4F4F5;
+}
+
 </style>

--- a/app/pages/user/[id].vue
+++ b/app/pages/user/[id].vue
@@ -72,4 +72,27 @@ useHead({
     text-decoration: underline;
   }
 }
+
+/* Dark mode styles */
+.dark-mode .user-view {
+  background-color: #2e2e2e;
+  color: #F4F4F5;
+
+  & h1 {
+    color: #F4F4F5;
+  }
+
+  .label {
+    color: #ccc;
+  }
+
+  .about {
+    color: #ccc;
+  }
+
+  .links a {
+    color: #00C48D;
+  }
+}
+
 </style>

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@nuxt/eslint": "^0.7.1",
     "@nuxt/eslint-config": "^0.7.1",
     "@nuxthub/core": "^0.8.7",
-    "@types/node": "^22.9.3",
+    "@types/node": "^22.9.4",
     "eslint": "^9.15.0",
     "nuxt": "^3.14.1592",
     "postcss-nesting": "^13.0.1",

--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
   },
   "devDependencies": {
     "@nuxt/devtools": "^1.6.1",
-    "@nuxt/eslint": "^0.7.1",
-    "@nuxt/eslint-config": "^0.7.1",
+    "@nuxt/eslint": "^0.7.2",
+    "@nuxt/eslint-config": "^0.7.2",
     "@nuxthub/core": "^0.8.7",
-    "@types/node": "^22.9.4",
+    "@types/node": "^22.10.0",
     "eslint": "^9.15.0",
     "nuxt": "^3.14.1592",
     "postcss-nesting": "^13.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,14 +18,14 @@ devDependencies:
     specifier: ^0.8.7
     version: 0.8.7(vite@5.4.11)
   '@types/node':
-    specifier: ^22.9.3
-    version: 22.9.3
+    specifier: ^22.9.4
+    version: 22.9.4
   eslint:
     specifier: ^9.15.0
     version: 9.15.0
   nuxt:
     specifier: ^3.14.1592
-    version: 3.14.1592(@types/node@22.9.3)(eslint@9.15.0)(typescript@5.7.2)(vite@5.4.11)
+    version: 3.14.1592(@types/node@22.9.4)(eslint@9.15.0)(typescript@5.7.2)(vite@5.4.11)
   postcss-nesting:
     specifier: ^13.0.1
     version: 13.0.1(postcss@8.4.49)
@@ -1157,7 +1157,7 @@ packages:
       '@nuxt/kit': 3.14.159
       '@nuxt/schema': 3.14.159
       execa: 7.2.0
-      vite: 5.4.11(@types/node@22.9.3)
+      vite: 5.4.11(@types/node@22.9.4)
     transitivePeerDependencies:
       - magicast
       - rollup
@@ -1173,7 +1173,7 @@ packages:
       '@nuxt/kit': 3.14.1592(magicast@0.3.5)
       '@nuxt/schema': 3.14.1592(magicast@0.3.5)
       execa: 7.2.0
-      vite: 5.4.11(@types/node@22.9.3)
+      vite: 5.4.11(@types/node@22.9.4)
     transitivePeerDependencies:
       - magicast
       - rollup
@@ -1236,7 +1236,7 @@ packages:
       sirv: 2.0.4
       tinyglobby: 0.2.10
       unimport: 3.13.2(rollup@4.24.4)
-      vite: 5.4.11(@types/node@22.9.3)
+      vite: 5.4.11(@types/node@22.9.4)
       vite-plugin-inspect: 0.8.7(@nuxt/kit@3.14.1592)(vite@5.4.11)
       vite-plugin-vue-inspector: 5.1.3(vite@5.4.11)
       which: 3.0.1
@@ -1477,7 +1477,7 @@ packages:
       - webpack-sources
     dev: true
 
-  /@nuxt/vite-builder@3.14.1592(@types/node@22.9.3)(eslint@9.15.0)(typescript@5.7.2)(vue@3.5.13):
+  /@nuxt/vite-builder@3.14.1592(@types/node@22.9.4)(eslint@9.15.0)(typescript@5.7.2)(vue@3.5.13):
     resolution: {integrity: sha512-GVS7vkBJAGv13ghmjgGrS2QVyzoqxQ5+cAUrMeMjKbY7GnRY7/uOkoLmznYx8E/U9HBUyHQa+wSN2ZfcSiEytQ==}
     engines: {node: ^14.18.0 || >=16.10.0}
     peerDependencies:
@@ -1513,8 +1513,8 @@ packages:
       ufo: 1.5.4
       unenv: 1.10.0
       unplugin: 1.16.0
-      vite: 5.4.11(@types/node@22.9.3)
-      vite-node: 2.1.5(@types/node@22.9.3)
+      vite: 5.4.11(@types/node@22.9.4)
+      vite-node: 2.1.5(@types/node@22.9.4)
       vite-plugin-checker: 0.8.0(eslint@9.15.0)(typescript@5.7.2)(vite@5.4.11)
       vue: 3.5.13(typescript@5.7.2)
       vue-bundle-renderer: 2.1.1
@@ -2082,15 +2082,15 @@ packages:
   /@types/http-proxy@1.17.15:
     resolution: {integrity: sha512-25g5atgiVNTIv0LBDTg1H74Hvayx0ajtJPLLcYE3whFv75J0pWNtOBzaXJQgDTmrX1bx5U9YC2w/n65BN1HwRQ==}
     dependencies:
-      '@types/node': 22.9.3
+      '@types/node': 22.9.4
     dev: true
 
   /@types/json-schema@7.0.15:
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
     dev: true
 
-  /@types/node@22.9.3:
-    resolution: {integrity: sha512-F3u1fs/fce3FFk+DAxbxc78DF8x0cY09RRL8GnXLmkJ1jvx3TtPdWoTT5/NiYfI5ASqXBmfqJi9dZ3gxMx4lzw==}
+  /@types/node@22.9.4:
+    resolution: {integrity: sha512-d9RWfoR7JC/87vj7n+PVTzGg9hDyuFjir3RxUHbjFSKNd9mpxbxwMEyaCim/ddCmy4IuW7HjTzF3g9p3EtWEOg==}
     dependencies:
       undici-types: 6.19.8
     dev: true
@@ -2369,7 +2369,7 @@ packages:
       '@babel/core': 7.26.0
       '@babel/plugin-transform-typescript': 7.25.9(@babel/core@7.26.0)
       '@vue/babel-plugin-jsx': 1.2.5(@babel/core@7.26.0)
-      vite: 5.4.11(@types/node@22.9.3)
+      vite: 5.4.11(@types/node@22.9.4)
       vue: 3.5.13(typescript@5.7.2)
     transitivePeerDependencies:
       - supports-color
@@ -2382,7 +2382,7 @@ packages:
       vite: ^5.0.0
       vue: ^3.2.25
     dependencies:
-      vite: 5.4.11(@types/node@22.9.3)
+      vite: 5.4.11(@types/node@22.9.4)
       vue: 3.5.13(typescript@5.7.2)
     dev: true
 
@@ -5277,7 +5277,7 @@ packages:
     hasBin: true
     dev: true
 
-  /nuxt@3.14.1592(@types/node@22.9.3)(eslint@9.15.0)(typescript@5.7.2)(vite@5.4.11):
+  /nuxt@3.14.1592(@types/node@22.9.4)(eslint@9.15.0)(typescript@5.7.2)(vite@5.4.11):
     resolution: {integrity: sha512-roWAQH4Mb6WY72cNos+YVw0DgTCNAhNygiAMCedM7hbX6ESTR2n3VH7tU0yIWDPe/hfFdii4M4wWTTNHOtS44g==}
     engines: {node: ^14.18.0 || >=16.10.0}
     hasBin: true
@@ -5295,8 +5295,8 @@ packages:
       '@nuxt/kit': 3.14.1592(magicast@0.3.5)
       '@nuxt/schema': 3.14.1592(magicast@0.3.5)
       '@nuxt/telemetry': 2.6.0
-      '@nuxt/vite-builder': 3.14.1592(@types/node@22.9.3)(eslint@9.15.0)(typescript@5.7.2)(vue@3.5.13)
-      '@types/node': 22.9.3
+      '@nuxt/vite-builder': 3.14.1592(@types/node@22.9.4)(eslint@9.15.0)(typescript@5.7.2)(vue@3.5.13)
+      '@types/node': 22.9.4
       '@unhead/dom': 1.11.11
       '@unhead/shared': 1.11.11
       '@unhead/ssr': 1.11.11
@@ -7049,10 +7049,10 @@ packages:
     peerDependencies:
       vite: ^2.6.0 || ^3.0.0 || ^4.0.0 || ^5.0.0-0
     dependencies:
-      vite: 5.4.11(@types/node@22.9.3)
+      vite: 5.4.11(@types/node@22.9.4)
     dev: true
 
-  /vite-node@2.1.5(@types/node@22.9.3):
+  /vite-node@2.1.5(@types/node@22.9.4):
     resolution: {integrity: sha512-rd0QIgx74q4S1Rd56XIiL2cYEdyWn13cunYBIuqh9mpmQr7gGS0IxXoP8R6OaZtNQQLyXSWbd4rXKYUbhFpK5w==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -7061,7 +7061,7 @@ packages:
       debug: 4.3.7(supports-color@9.4.0)
       es-module-lexer: 1.5.4
       pathe: 1.1.2
-      vite: 5.4.11(@types/node@22.9.3)
+      vite: 5.4.11(@types/node@22.9.4)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -7120,7 +7120,7 @@ packages:
       strip-ansi: 6.0.1
       tiny-invariant: 1.3.1
       typescript: 5.7.2
-      vite: 5.4.11(@types/node@22.9.3)
+      vite: 5.4.11(@types/node@22.9.4)
       vscode-languageclient: 7.0.0
       vscode-languageserver: 7.0.0
       vscode-languageserver-textdocument: 1.0.8
@@ -7147,7 +7147,7 @@ packages:
       perfect-debounce: 1.0.0
       picocolors: 1.1.1
       sirv: 2.0.4
-      vite: 5.4.11(@types/node@22.9.3)
+      vite: 5.4.11(@types/node@22.9.4)
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -7167,12 +7167,12 @@ packages:
       '@vue/compiler-dom': 3.5.13
       kolorist: 1.8.0
       magic-string: 0.30.13
-      vite: 5.4.11(@types/node@22.9.3)
+      vite: 5.4.11(@types/node@22.9.4)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /vite@5.4.11(@types/node@22.9.3):
+  /vite@5.4.11(@types/node@22.9.4):
     resolution: {integrity: sha512-c7jFQRklXua0mTzneGW9QVyxFjUgwcihC4bXEtujIo2ouWCe1Ajt/amn2PCxYnhYfd5k09JX3SB7OYWFKYqj8Q==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -7203,7 +7203,7 @@ packages:
       terser:
         optional: true
     dependencies:
-      '@types/node': 22.9.3
+      '@types/node': 22.9.4
       esbuild: 0.21.5
       postcss: 8.4.49
       rollup: 4.24.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,23 +9,23 @@ devDependencies:
     specifier: ^1.6.1
     version: 1.6.1(vite@5.4.11)(vue@3.5.13)
   '@nuxt/eslint':
-    specifier: ^0.7.1
-    version: 0.7.1(@vue/compiler-sfc@3.5.13)(eslint@9.15.0)(typescript@5.7.2)(vite@5.4.11)
+    specifier: ^0.7.2
+    version: 0.7.2(@vue/compiler-sfc@3.5.13)(eslint@9.15.0)(typescript@5.7.2)(vite@5.4.11)
   '@nuxt/eslint-config':
-    specifier: ^0.7.1
-    version: 0.7.1(@vue/compiler-sfc@3.5.13)(eslint@9.15.0)(typescript@5.7.2)
+    specifier: ^0.7.2
+    version: 0.7.2(@vue/compiler-sfc@3.5.13)(eslint@9.15.0)(typescript@5.7.2)
   '@nuxthub/core':
     specifier: ^0.8.7
     version: 0.8.7(vite@5.4.11)
   '@types/node':
-    specifier: ^22.9.4
-    version: 22.9.4
+    specifier: ^22.10.0
+    version: 22.10.0
   eslint:
     specifier: ^9.15.0
     version: 9.15.0
   nuxt:
     specifier: ^3.14.1592
-    version: 3.14.1592(@types/node@22.9.4)(eslint@9.15.0)(typescript@5.7.2)(vite@5.4.11)
+    version: 3.14.1592(@types/node@22.10.0)(eslint@9.15.0)(typescript@5.7.2)(vite@5.4.11)
   postcss-nesting:
     specifier: ^13.0.1
     version: 13.0.1(postcss@8.4.49)
@@ -373,22 +373,20 @@ packages:
       '@babel/helper-validator-identifier': 7.25.9
     dev: true
 
-  /@clack/core@0.3.4:
-    resolution: {integrity: sha512-H4hxZDXgHtWTwV3RAVenqcC4VbJZNegbBjlPvzOzCouXtS2y3sDvlO3IsbrPNWuLWPPlYVYPghQdSF64683Ldw==}
+  /@clack/core@0.3.5:
+    resolution: {integrity: sha512-5cfhQNH+1VQ2xLQlmzXMqUoiaH0lRBq9/CLW9lTyMbuKLC3+xEK01tHVvyut++mLOn5urSHmkm6I0Lg9MaJSTQ==}
     dependencies:
       picocolors: 1.1.1
       sisteransi: 1.0.5
     dev: true
 
-  /@clack/prompts@0.8.1:
-    resolution: {integrity: sha512-I263nEUNbX4lPTX93trl1fkIvGrGlz6nUYkqOddF0ZmjqcxUgUlXmpUIUqfapirRKJrFddvwF+qdZgg8cSqF7g==}
+  /@clack/prompts@0.8.2:
+    resolution: {integrity: sha512-6b9Ab2UiZwJYA9iMyboYyW9yJvAO9V753ZhS+DHKEjZRKAxPPOb7MXXu84lsPFG+vZt6FRFniZ8rXi+zCIw4yQ==}
     dependencies:
-      '@clack/core': 0.3.4
+      '@clack/core': 0.3.5
       picocolors: 1.1.1
       sisteransi: 1.0.5
     dev: true
-    bundledDependencies:
-      - is-unicode-supported
 
   /@cloudflare/kv-asset-handler@0.3.4:
     resolution: {integrity: sha512-YLPHc8yASwjNkmcDMQMY35yiWjoKAKnhUbPRszBRS0YgH+IXtsMp61j+yTcnCE3oO2DgP0U3iejLC8FTtKDC8Q==}
@@ -1154,15 +1152,14 @@ packages:
     peerDependencies:
       vite: '*'
     dependencies:
-      '@nuxt/kit': 3.14.159
-      '@nuxt/schema': 3.14.159
+      '@nuxt/kit': 3.14.1592(magicast@0.3.5)
+      '@nuxt/schema': 3.14.1592(magicast@0.3.5)
       execa: 7.2.0
-      vite: 5.4.11(@types/node@22.9.4)
+      vite: 5.4.11(@types/node@22.10.0)
     transitivePeerDependencies:
       - magicast
       - rollup
       - supports-color
-      - webpack-sources
     dev: true
 
   /@nuxt/devtools-kit@1.6.1(magicast@0.3.5)(vite@5.4.11):
@@ -1173,12 +1170,11 @@ packages:
       '@nuxt/kit': 3.14.1592(magicast@0.3.5)
       '@nuxt/schema': 3.14.1592(magicast@0.3.5)
       execa: 7.2.0
-      vite: 5.4.11(@types/node@22.9.4)
+      vite: 5.4.11(@types/node@22.10.0)
     transitivePeerDependencies:
       - magicast
       - rollup
       - supports-color
-      - webpack-sources
     dev: true
 
   /@nuxt/devtools-wizard@1.6.1:
@@ -1236,7 +1232,7 @@ packages:
       sirv: 2.0.4
       tinyglobby: 0.2.10
       unimport: 3.13.2(rollup@4.24.4)
-      vite: 5.4.11(@types/node@22.9.4)
+      vite: 5.4.11(@types/node@22.10.0)
       vite-plugin-inspect: 0.8.7(@nuxt/kit@3.14.1592)(vite@5.4.11)
       vite-plugin-vue-inspector: 5.1.3(vite@5.4.11)
       which: 3.0.1
@@ -1247,11 +1243,10 @@ packages:
       - supports-color
       - utf-8-validate
       - vue
-      - webpack-sources
     dev: true
 
-  /@nuxt/eslint-config@0.7.1(@vue/compiler-sfc@3.5.13)(eslint@9.15.0)(typescript@5.7.2):
-    resolution: {integrity: sha512-y0sO0+gle+FV7g4tKQgiB8PT2sTnpND63K/PmwU+VAucz4XTCbMlI2l0tCdfQCreXtFhskFKQrJ9dGcna5eakg==}
+  /@nuxt/eslint-config@0.7.2(@vue/compiler-sfc@3.5.13)(eslint@9.15.0)(typescript@5.7.2):
+    resolution: {integrity: sha512-zSXSIrfKwEPUP3tElxXuurn89PagBhA0KN2L6t+EW4FvGLVDDqUB53Wp4Srpqo5yAkGmp43IeF3PiQXZJaFtwQ==}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
       eslint-plugin-format: '*'
@@ -1260,24 +1255,24 @@ packages:
         optional: true
     dependencies:
       '@antfu/install-pkg': 0.4.1
-      '@clack/prompts': 0.8.1
+      '@clack/prompts': 0.8.2
       '@eslint/js': 9.15.0
-      '@nuxt/eslint-plugin': 0.7.1(eslint@9.15.0)(typescript@5.7.2)
-      '@stylistic/eslint-plugin': 2.10.1(eslint@9.15.0)(typescript@5.7.2)
-      '@typescript-eslint/eslint-plugin': 8.15.0(@typescript-eslint/parser@8.15.0)(eslint@9.15.0)(typescript@5.7.2)
-      '@typescript-eslint/parser': 8.15.0(eslint@9.15.0)(typescript@5.7.2)
+      '@nuxt/eslint-plugin': 0.7.2(eslint@9.15.0)(typescript@5.7.2)
+      '@stylistic/eslint-plugin': 2.11.0(eslint@9.15.0)(typescript@5.7.2)
+      '@typescript-eslint/eslint-plugin': 8.16.0(@typescript-eslint/parser@8.16.0)(eslint@9.15.0)(typescript@5.7.2)
+      '@typescript-eslint/parser': 8.16.0(eslint@9.15.0)(typescript@5.7.2)
       eslint: 9.15.0
       eslint-config-flat-gitignore: 0.2.0(eslint@9.15.0)
       eslint-flat-config-utils: 0.4.0
       eslint-merge-processors: 0.1.0(eslint@9.15.0)
-      eslint-plugin-import-x: 4.4.2(eslint@9.15.0)(typescript@5.7.2)
+      eslint-plugin-import-x: 4.4.3(eslint@9.15.0)(typescript@5.7.2)
       eslint-plugin-jsdoc: 50.5.0(eslint@9.15.0)
       eslint-plugin-regexp: 2.7.0(eslint@9.15.0)
-      eslint-plugin-unicorn: 56.0.0(eslint@9.15.0)
+      eslint-plugin-unicorn: 56.0.1(eslint@9.15.0)
       eslint-plugin-vue: 9.31.0(eslint@9.15.0)
       eslint-processor-vue-blocks: 0.1.2(@vue/compiler-sfc@3.5.13)(eslint@9.15.0)
       globals: 15.12.0
-      local-pkg: 0.5.0
+      local-pkg: 0.5.1
       pathe: 1.1.2
       vue-eslint-parser: 9.4.3(eslint@9.15.0)
     transitivePeerDependencies:
@@ -1286,21 +1281,21 @@ packages:
       - typescript
     dev: true
 
-  /@nuxt/eslint-plugin@0.7.1(eslint@9.15.0)(typescript@5.7.2):
-    resolution: {integrity: sha512-/COfuye/C6PBlsKq1u9gZXN4recYe9bcmgNVPNnc8cSs55iilS1vPg7uBXG/nANzwdrngJ9j7hMP1PUKOiRiEg==}
+  /@nuxt/eslint-plugin@0.7.2(eslint@9.15.0)(typescript@5.7.2):
+    resolution: {integrity: sha512-9r2Sm1rWHc8TGDn1TsXCnT4vg2Y7lHfGPZEeJ+OSgC6VY1HMxF+roglIU5wlU8dxafX7FqX2UwlF+Uux6M4bJA==}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
     dependencies:
-      '@typescript-eslint/types': 8.15.0
-      '@typescript-eslint/utils': 8.15.0(eslint@9.15.0)(typescript@5.7.2)
+      '@typescript-eslint/types': 8.16.0
+      '@typescript-eslint/utils': 8.16.0(eslint@9.15.0)(typescript@5.7.2)
       eslint: 9.15.0
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /@nuxt/eslint@0.7.1(@vue/compiler-sfc@3.5.13)(eslint@9.15.0)(typescript@5.7.2)(vite@5.4.11):
-    resolution: {integrity: sha512-UO7buQvhmiBArcuWrK1XFuC4drHxRgWxldwN1pvVKxKOeVhaomp4TlkOJAiyw2p3xIItQX4jV+SSVxnzoaF7UQ==}
+  /@nuxt/eslint@0.7.2(@vue/compiler-sfc@3.5.13)(eslint@9.15.0)(typescript@5.7.2)(vite@5.4.11):
+    resolution: {integrity: sha512-vYHeSkl9GnLUNXQQU2hupytalgD2mqDg2hrONzu+cayaow4YsqkbtrInNsvUMpH1PsvfFMonv3YK+hvptArTVw==}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
       eslint-webpack-plugin: ^4.1.0
@@ -1312,10 +1307,10 @@ packages:
         optional: true
     dependencies:
       '@eslint/config-inspector': 0.5.6(eslint@9.15.0)
-      '@nuxt/devtools-kit': 1.6.0(vite@5.4.11)
-      '@nuxt/eslint-config': 0.7.1(@vue/compiler-sfc@3.5.13)(eslint@9.15.0)(typescript@5.7.2)
-      '@nuxt/eslint-plugin': 0.7.1(eslint@9.15.0)(typescript@5.7.2)
-      '@nuxt/kit': 3.14.159
+      '@nuxt/devtools-kit': 1.6.1(magicast@0.3.5)(vite@5.4.11)
+      '@nuxt/eslint-config': 0.7.2(@vue/compiler-sfc@3.5.13)(eslint@9.15.0)(typescript@5.7.2)
+      '@nuxt/eslint-plugin': 0.7.2(eslint@9.15.0)(typescript@5.7.2)
+      '@nuxt/kit': 3.14.1592(magicast@0.3.5)
       chokidar: 4.0.1
       eslint: 9.15.0
       eslint-flat-config-utils: 0.4.0
@@ -1324,7 +1319,7 @@ packages:
       get-port-please: 3.1.2
       mlly: 1.7.3
       pathe: 1.1.2
-      unimport: 3.13.2(rollup@4.24.4)
+      unimport: 3.13.3
     transitivePeerDependencies:
       - '@vue/compiler-sfc'
       - bufferutil
@@ -1335,7 +1330,6 @@ packages:
       - typescript
       - utf-8-validate
       - vite
-      - webpack-sources
     dev: true
 
   /@nuxt/kit@3.14.159:
@@ -1366,7 +1360,6 @@ packages:
       - magicast
       - rollup
       - supports-color
-      - webpack-sources
     dev: true
 
   /@nuxt/kit@3.14.1592(magicast@0.3.5):
@@ -1391,13 +1384,12 @@ packages:
       semver: 7.6.3
       ufo: 1.5.4
       unctx: 2.3.1
-      unimport: 3.13.2(rollup@4.24.4)
+      unimport: 3.13.3
       untyped: 1.5.1
     transitivePeerDependencies:
       - magicast
       - rollup
       - supports-color
-      - webpack-sources
     dev: true
 
   /@nuxt/schema@3.14.159:
@@ -1421,7 +1413,6 @@ packages:
       - magicast
       - rollup
       - supports-color
-      - webpack-sources
     dev: true
 
   /@nuxt/schema@3.14.1592(magicast@0.3.5):
@@ -1445,7 +1436,6 @@ packages:
       - magicast
       - rollup
       - supports-color
-      - webpack-sources
     dev: true
 
   /@nuxt/telemetry@2.6.0:
@@ -1474,10 +1464,9 @@ packages:
       - magicast
       - rollup
       - supports-color
-      - webpack-sources
     dev: true
 
-  /@nuxt/vite-builder@3.14.1592(@types/node@22.9.4)(eslint@9.15.0)(typescript@5.7.2)(vue@3.5.13):
+  /@nuxt/vite-builder@3.14.1592(@types/node@22.10.0)(eslint@9.15.0)(typescript@5.7.2)(vue@3.5.13):
     resolution: {integrity: sha512-GVS7vkBJAGv13ghmjgGrS2QVyzoqxQ5+cAUrMeMjKbY7GnRY7/uOkoLmznYx8E/U9HBUyHQa+wSN2ZfcSiEytQ==}
     engines: {node: ^14.18.0 || >=16.10.0}
     peerDependencies:
@@ -1513,8 +1502,8 @@ packages:
       ufo: 1.5.4
       unenv: 1.10.0
       unplugin: 1.16.0
-      vite: 5.4.11(@types/node@22.9.4)
-      vite-node: 2.1.5(@types/node@22.9.4)
+      vite: 5.4.11(@types/node@22.10.0)
+      vite-node: 2.1.5(@types/node@22.10.0)
       vite-plugin-checker: 0.8.0(eslint@9.15.0)(typescript@5.7.2)(vite@5.4.11)
       vue: 3.5.13(typescript@5.7.2)
       vue-bundle-renderer: 2.1.1
@@ -1539,7 +1528,6 @@ packages:
       - vls
       - vti
       - vue-tsc
-      - webpack-sources
     dev: true
 
   /@nuxthub/core@0.8.7(vite@5.4.11):
@@ -1582,7 +1570,6 @@ packages:
       - rollup
       - supports-color
       - vite
-      - webpack-sources
     dev: true
 
   /@parcel/watcher-android-arm64@2.4.1:
@@ -2053,13 +2040,13 @@ packages:
     engines: {node: '>=18'}
     dev: true
 
-  /@stylistic/eslint-plugin@2.10.1(eslint@9.15.0)(typescript@5.7.2):
-    resolution: {integrity: sha512-U+4yzNXElTf9q0kEfnloI9XbOyD4cnEQCxjUI94q0+W++0GAEQvJ/slwEj9lwjDHfGADRSr+Tco/z0XJvmDfCQ==}
+  /@stylistic/eslint-plugin@2.11.0(eslint@9.15.0)(typescript@5.7.2):
+    resolution: {integrity: sha512-PNRHbydNG5EH8NK4c+izdJlxajIR6GxcUhzsYNRsn6Myep4dsZt0qFCz3rCPnkvgO5FYibDcMqgNHUT+zvjYZw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: '>=8.40.0'
     dependencies:
-      '@typescript-eslint/utils': 8.14.0(eslint@9.15.0)(typescript@5.7.2)
+      '@typescript-eslint/utils': 8.15.0(eslint@9.15.0)(typescript@5.7.2)
       eslint: 9.15.0
       eslint-visitor-keys: 4.2.0
       espree: 10.3.0
@@ -2082,17 +2069,17 @@ packages:
   /@types/http-proxy@1.17.15:
     resolution: {integrity: sha512-25g5atgiVNTIv0LBDTg1H74Hvayx0ajtJPLLcYE3whFv75J0pWNtOBzaXJQgDTmrX1bx5U9YC2w/n65BN1HwRQ==}
     dependencies:
-      '@types/node': 22.9.4
+      '@types/node': 22.10.0
     dev: true
 
   /@types/json-schema@7.0.15:
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
     dev: true
 
-  /@types/node@22.9.4:
-    resolution: {integrity: sha512-d9RWfoR7JC/87vj7n+PVTzGg9hDyuFjir3RxUHbjFSKNd9mpxbxwMEyaCim/ddCmy4IuW7HjTzF3g9p3EtWEOg==}
+  /@types/node@22.10.0:
+    resolution: {integrity: sha512-XC70cRZVElFHfIUB40FgZOBbgJYFKKMa5nb9lxcwYstFG/Mi+/Y0bGS+rs6Dmhmkpq4pnNiLiuZAbc02YCOnmA==}
     dependencies:
-      undici-types: 6.19.8
+      undici-types: 6.20.0
     dev: true
 
   /@types/normalize-package-data@2.4.4:
@@ -2103,8 +2090,8 @@ packages:
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
     dev: true
 
-  /@typescript-eslint/eslint-plugin@8.15.0(@typescript-eslint/parser@8.15.0)(eslint@9.15.0)(typescript@5.7.2):
-    resolution: {integrity: sha512-+zkm9AR1Ds9uLWN3fkoeXgFppaQ+uEVtfOV62dDmsy9QCNqlRHWNEck4yarvRNrvRcHQLGfqBNui3cimoz8XAg==}
+  /@typescript-eslint/eslint-plugin@8.16.0(@typescript-eslint/parser@8.16.0)(eslint@9.15.0)(typescript@5.7.2):
+    resolution: {integrity: sha512-5YTHKV8MYlyMI6BaEG7crQ9BhSc8RxzshOReKwZwRWN0+XvvTOm+L/UYLCYxFpfwYuAAqhxiq4yae0CMFwbL7Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       '@typescript-eslint/parser': ^8.0.0 || ^8.0.0-alpha.0
@@ -2115,11 +2102,11 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.15.0(eslint@9.15.0)(typescript@5.7.2)
-      '@typescript-eslint/scope-manager': 8.15.0
-      '@typescript-eslint/type-utils': 8.15.0(eslint@9.15.0)(typescript@5.7.2)
-      '@typescript-eslint/utils': 8.15.0(eslint@9.15.0)(typescript@5.7.2)
-      '@typescript-eslint/visitor-keys': 8.15.0
+      '@typescript-eslint/parser': 8.16.0(eslint@9.15.0)(typescript@5.7.2)
+      '@typescript-eslint/scope-manager': 8.16.0
+      '@typescript-eslint/type-utils': 8.16.0(eslint@9.15.0)(typescript@5.7.2)
+      '@typescript-eslint/utils': 8.16.0(eslint@9.15.0)(typescript@5.7.2)
+      '@typescript-eslint/visitor-keys': 8.16.0
       eslint: 9.15.0
       graphemer: 1.4.0
       ignore: 5.3.2
@@ -2130,8 +2117,8 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@8.15.0(eslint@9.15.0)(typescript@5.7.2):
-    resolution: {integrity: sha512-7n59qFpghG4uazrF9qtGKBZXn7Oz4sOMm8dwNWDQY96Xlm2oX67eipqcblDj+oY1lLCbf1oltMZFpUso66Kl1A==}
+  /@typescript-eslint/parser@8.16.0(eslint@9.15.0)(typescript@5.7.2):
+    resolution: {integrity: sha512-D7DbgGFtsqIPIFMPJwCad9Gfi/hC0PWErRRHFnaCWoEDYi5tQUDiJCTmGUbBiLzjqAck4KcXt9Ayj0CNlIrF+w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
@@ -2140,23 +2127,15 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/scope-manager': 8.15.0
-      '@typescript-eslint/types': 8.15.0
-      '@typescript-eslint/typescript-estree': 8.15.0(typescript@5.7.2)
-      '@typescript-eslint/visitor-keys': 8.15.0
+      '@typescript-eslint/scope-manager': 8.16.0
+      '@typescript-eslint/types': 8.16.0
+      '@typescript-eslint/typescript-estree': 8.16.0(typescript@5.7.2)
+      '@typescript-eslint/visitor-keys': 8.16.0
       debug: 4.3.7(supports-color@9.4.0)
       eslint: 9.15.0
       typescript: 5.7.2
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /@typescript-eslint/scope-manager@8.14.0:
-    resolution: {integrity: sha512-aBbBrnW9ARIDn92Zbo7rguLnqQ/pOrUguVpbUwzOhkFg2npFDwTgPGqFqE0H5feXcOoJOfX3SxlJaKEVtq54dw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    dependencies:
-      '@typescript-eslint/types': 8.14.0
-      '@typescript-eslint/visitor-keys': 8.14.0
     dev: true
 
   /@typescript-eslint/scope-manager@8.15.0:
@@ -2167,8 +2146,16 @@ packages:
       '@typescript-eslint/visitor-keys': 8.15.0
     dev: true
 
-  /@typescript-eslint/type-utils@8.15.0(eslint@9.15.0)(typescript@5.7.2):
-    resolution: {integrity: sha512-UU6uwXDoI3JGSXmcdnP5d8Fffa2KayOhUUqr/AiBnG1Gl7+7ut/oyagVeSkh7bxQ0zSXV9ptRh/4N15nkCqnpw==}
+  /@typescript-eslint/scope-manager@8.16.0:
+    resolution: {integrity: sha512-mwsZWubQvBki2t5565uxF0EYvG+FwdFb8bMtDuGQLdCCnGPrDEDvm1gtfynuKlnpzeBRqdFCkMf9jg1fnAK8sg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    dependencies:
+      '@typescript-eslint/types': 8.16.0
+      '@typescript-eslint/visitor-keys': 8.16.0
+    dev: true
+
+  /@typescript-eslint/type-utils@8.16.0(eslint@9.15.0)(typescript@5.7.2):
+    resolution: {integrity: sha512-IqZHGG+g1XCWX9NyqnI/0CX5LL8/18awQqmkZSl2ynn8F76j579dByc0jhfVSnSnhf7zv76mKBQv9HQFKvDCgg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
@@ -2177,8 +2164,8 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 8.15.0(typescript@5.7.2)
-      '@typescript-eslint/utils': 8.15.0(eslint@9.15.0)(typescript@5.7.2)
+      '@typescript-eslint/typescript-estree': 8.16.0(typescript@5.7.2)
+      '@typescript-eslint/utils': 8.16.0(eslint@9.15.0)(typescript@5.7.2)
       debug: 4.3.7(supports-color@9.4.0)
       eslint: 9.15.0
       ts-api-utils: 1.3.0(typescript@5.7.2)
@@ -2187,36 +2174,14 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/types@8.14.0:
-    resolution: {integrity: sha512-yjeB9fnO/opvLJFAsPNYlKPnEM8+z4og09Pk504dkqonT02AyL5Z9SSqlE0XqezS93v6CXn49VHvB2G7XSsl0g==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    dev: true
-
   /@typescript-eslint/types@8.15.0:
     resolution: {integrity: sha512-n3Gt8Y/KyJNe0S3yDCD2RVKrHBC4gTUcLTebVBXacPy091E6tNspFLKRXlk3hwT4G55nfr1n2AdFqi/XMxzmPQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     dev: true
 
-  /@typescript-eslint/typescript-estree@8.14.0(typescript@5.7.2):
-    resolution: {integrity: sha512-OPXPLYKGZi9XS/49rdaCbR5j/S14HazviBlUQFvSKz3npr3NikF+mrgK7CFVur6XEt95DZp/cmke9d5i3vtVnQ==}
+  /@typescript-eslint/types@8.16.0:
+    resolution: {integrity: sha512-NzrHj6thBAOSE4d9bsuRNMvk+BvaQvmY4dDglgkgGC0EW/tB3Kelnp3tAKH87GEwzoxgeQn9fNGRyFJM/xd+GQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/types': 8.14.0
-      '@typescript-eslint/visitor-keys': 8.14.0
-      debug: 4.3.7(supports-color@9.4.0)
-      fast-glob: 3.3.2
-      is-glob: 4.0.3
-      minimatch: 9.0.5
-      semver: 7.6.3
-      ts-api-utils: 1.3.0(typescript@5.7.2)
-      typescript: 5.7.2
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@typescript-eslint/typescript-estree@8.15.0(typescript@5.7.2):
@@ -2241,20 +2206,26 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils@8.14.0(eslint@9.15.0)(typescript@5.7.2):
-    resolution: {integrity: sha512-OGqj6uB8THhrHj0Fk27DcHPojW7zKwKkPmHXHvQ58pLYp4hy8CSUdTKykKeh+5vFqTTVmjz0zCOOPKRovdsgHA==}
+  /@typescript-eslint/typescript-estree@8.16.0(typescript@5.7.2):
+    resolution: {integrity: sha512-E2+9IzzXMc1iaBy9zmo+UYvluE3TW7bCGWSF41hVWUE01o8nzr1rvOQYSxelxr6StUvRcTMe633eY8mXASMaNw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@9.15.0)
-      '@typescript-eslint/scope-manager': 8.14.0
-      '@typescript-eslint/types': 8.14.0
-      '@typescript-eslint/typescript-estree': 8.14.0(typescript@5.7.2)
-      eslint: 9.15.0
+      '@typescript-eslint/types': 8.16.0
+      '@typescript-eslint/visitor-keys': 8.16.0
+      debug: 4.3.7(supports-color@9.4.0)
+      fast-glob: 3.3.2
+      is-glob: 4.0.3
+      minimatch: 9.0.5
+      semver: 7.6.3
+      ts-api-utils: 1.3.0(typescript@5.7.2)
+      typescript: 5.7.2
     transitivePeerDependencies:
       - supports-color
-      - typescript
     dev: true
 
   /@typescript-eslint/utils@8.15.0(eslint@9.15.0)(typescript@5.7.2):
@@ -2277,12 +2248,24 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/visitor-keys@8.14.0:
-    resolution: {integrity: sha512-vG0XZo8AdTH9OE6VFRwAZldNc7qtJ/6NLGWak+BtENuEUXGZgFpihILPiBvKXvJ2nFu27XNGC6rKiwuaoMbYzQ==}
+  /@typescript-eslint/utils@8.16.0(eslint@9.15.0)(typescript@5.7.2):
+    resolution: {integrity: sha512-C1zRy/mOL8Pj157GiX4kaw7iyRLKfJXBR3L82hk5kS/GyHcOFmy4YUq/zfZti72I9wnuQtA/+xzft4wCC8PJdA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
     dependencies:
-      '@typescript-eslint/types': 8.14.0
-      eslint-visitor-keys: 3.4.3
+      '@eslint-community/eslint-utils': 4.4.0(eslint@9.15.0)
+      '@typescript-eslint/scope-manager': 8.16.0
+      '@typescript-eslint/types': 8.16.0
+      '@typescript-eslint/typescript-estree': 8.16.0(typescript@5.7.2)
+      eslint: 9.15.0
+      typescript: 5.7.2
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /@typescript-eslint/visitor-keys@8.15.0:
@@ -2290,6 +2273,14 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     dependencies:
       '@typescript-eslint/types': 8.15.0
+      eslint-visitor-keys: 4.2.0
+    dev: true
+
+  /@typescript-eslint/visitor-keys@8.16.0:
+    resolution: {integrity: sha512-pq19gbaMOmFE3CbL0ZB8J8BFCo2ckfHBfaIsaOZgBIF4EoISJIdLX5xRhd0FGB0LlHReNRuzoJoMGpTjq8F2CQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    dependencies:
+      '@typescript-eslint/types': 8.16.0
       eslint-visitor-keys: 4.2.0
     dev: true
 
@@ -2369,7 +2360,7 @@ packages:
       '@babel/core': 7.26.0
       '@babel/plugin-transform-typescript': 7.25.9(@babel/core@7.26.0)
       '@vue/babel-plugin-jsx': 1.2.5(@babel/core@7.26.0)
-      vite: 5.4.11(@types/node@22.9.4)
+      vite: 5.4.11(@types/node@22.10.0)
       vue: 3.5.13(typescript@5.7.2)
     transitivePeerDependencies:
       - supports-color
@@ -2382,7 +2373,7 @@ packages:
       vite: ^5.0.0
       vue: ^3.2.25
     dependencies:
-      vite: 5.4.11(@types/node@22.9.4)
+      vite: 5.4.11(@types/node@22.10.0)
       vue: 3.5.13(typescript@5.7.2)
     dev: true
 
@@ -3665,13 +3656,13 @@ packages:
       eslint: 9.15.0
     dev: true
 
-  /eslint-plugin-import-x@4.4.2(eslint@9.15.0)(typescript@5.7.2):
-    resolution: {integrity: sha512-mDRXPSLQ0UQZQw91QdG4/qZT6hgeW2MJTczAbgPseUZuPEtIjjdPOolXroRkulnOn3fzj6gNgvk+wchMJiHElg==}
+  /eslint-plugin-import-x@4.4.3(eslint@9.15.0)(typescript@5.7.2):
+    resolution: {integrity: sha512-QBprHvhLsfDhP++2T1NnjsOUt6bLDX3NMHaYwAB1FD3xmYTkdFH+HS1OamGhz28jLkRyIZa6UNAzTxbHnJwz5w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
     dependencies:
-      '@typescript-eslint/utils': 8.14.0(eslint@9.15.0)(typescript@5.7.2)
+      '@typescript-eslint/utils': 8.15.0(eslint@9.15.0)(typescript@5.7.2)
       debug: 4.3.7(supports-color@9.4.0)
       doctrine: 3.0.0
       eslint: 9.15.0
@@ -3725,8 +3716,8 @@ packages:
       scslre: 0.3.0
     dev: true
 
-  /eslint-plugin-unicorn@56.0.0(eslint@9.15.0):
-    resolution: {integrity: sha512-aXpddVz/PQMmd69uxO98PA4iidiVNvA0xOtbpUoz1WhBd4RxOQQYqN618v68drY0hmy5uU2jy1bheKEVWBjlPw==}
+  /eslint-plugin-unicorn@56.0.1(eslint@9.15.0):
+    resolution: {integrity: sha512-FwVV0Uwf8XPfVnKSGpMg7NtlZh0G0gBarCaFcMUOoqPxXryxdYxTRRv4kH6B9TFCVIrjRXG+emcxIk2ayZilog==}
     engines: {node: '>=18.18'}
     peerDependencies:
       eslint: '>=8.56.0'
@@ -4818,6 +4809,14 @@ packages:
       pkg-types: 1.2.1
     dev: true
 
+  /local-pkg@0.5.1:
+    resolution: {integrity: sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==}
+    engines: {node: '>=14'}
+    dependencies:
+      mlly: 1.7.3
+      pkg-types: 1.2.1
+    dev: true
+
   /locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
@@ -4882,12 +4881,6 @@ packages:
     engines: {node: '>=16.14.0'}
     dependencies:
       magic-string: 0.30.13
-    dev: true
-
-  /magic-string@0.30.12:
-    resolution: {integrity: sha512-Ea8I3sQMVXr8JhN4z+H/d8zwo+tYDgHE9+5G4Wnrwhs0gaK9fXTKx0Tw5Xwsd/bCPTTZNRAdpyzvoeORe9LYpw==}
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.0
     dev: true
 
   /magic-string@0.30.13:
@@ -5177,7 +5170,6 @@ packages:
       - mysql2
       - supports-color
       - typescript
-      - webpack-sources
     dev: true
 
   /node-addon-api@7.0.0:
@@ -5277,7 +5269,7 @@ packages:
     hasBin: true
     dev: true
 
-  /nuxt@3.14.1592(@types/node@22.9.4)(eslint@9.15.0)(typescript@5.7.2)(vite@5.4.11):
+  /nuxt@3.14.1592(@types/node@22.10.0)(eslint@9.15.0)(typescript@5.7.2)(vite@5.4.11):
     resolution: {integrity: sha512-roWAQH4Mb6WY72cNos+YVw0DgTCNAhNygiAMCedM7hbX6ESTR2n3VH7tU0yIWDPe/hfFdii4M4wWTTNHOtS44g==}
     engines: {node: ^14.18.0 || >=16.10.0}
     hasBin: true
@@ -5295,8 +5287,8 @@ packages:
       '@nuxt/kit': 3.14.1592(magicast@0.3.5)
       '@nuxt/schema': 3.14.1592(magicast@0.3.5)
       '@nuxt/telemetry': 2.6.0
-      '@nuxt/vite-builder': 3.14.1592(@types/node@22.9.4)(eslint@9.15.0)(typescript@5.7.2)(vue@3.5.13)
-      '@types/node': 22.9.4
+      '@nuxt/vite-builder': 3.14.1592(@types/node@22.10.0)(eslint@9.15.0)(typescript@5.7.2)(vue@3.5.13)
+      '@types/node': 22.10.0
       '@unhead/dom': 1.11.11
       '@unhead/shared': 1.11.11
       '@unhead/ssr': 1.11.11
@@ -5397,7 +5389,6 @@ packages:
       - vls
       - vti
       - vue-tsc
-      - webpack-sources
       - xml2js
     dev: true
 
@@ -6809,8 +6800,8 @@ packages:
       unplugin: 1.16.0
     dev: true
 
-  /undici-types@6.19.8:
-    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
+  /undici-types@6.20.0:
+    resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
     dev: true
 
   /unenv@1.10.0:
@@ -6846,16 +6837,35 @@ packages:
       estree-walker: 3.0.3
       fast-glob: 3.3.2
       local-pkg: 0.5.0
-      magic-string: 0.30.12
+      magic-string: 0.30.13
       mlly: 1.7.3
       pathe: 1.1.2
       pkg-types: 1.2.1
       scule: 1.3.0
       strip-literal: 2.1.0
-      unplugin: 1.15.0
+      unplugin: 1.16.0
     transitivePeerDependencies:
       - rollup
-      - webpack-sources
+    dev: true
+
+  /unimport@3.13.3:
+    resolution: {integrity: sha512-dr7sjOoRFCSDlnARFPAMB8OmjIMc6j14qd749VmB1yiqFEYFbi+1jWPTuc22JoFs/t1kHJXT3vQNiwCy3ZvsTA==}
+    dependencies:
+      '@rollup/pluginutils': 5.1.3(rollup@4.24.4)
+      acorn: 8.14.0
+      escape-string-regexp: 5.0.0
+      estree-walker: 3.0.3
+      fast-glob: 3.3.2
+      local-pkg: 0.5.1
+      magic-string: 0.30.13
+      mlly: 1.7.3
+      pathe: 1.1.2
+      pkg-types: 1.2.1
+      scule: 1.3.0
+      strip-literal: 2.1.0
+      unplugin: 1.16.0
+    transitivePeerDependencies:
+      - rollup
     dev: true
 
   /universalify@2.0.0:
@@ -6889,19 +6899,6 @@ packages:
     transitivePeerDependencies:
       - rollup
       - vue
-    dev: true
-
-  /unplugin@1.15.0:
-    resolution: {integrity: sha512-jTPIs63W+DUEDW207ztbaoO7cQ4p5aVaB823LSlxpsFEU3Mykwxf3ZGC/wzxFJeZlASZYgVrWeo7LgOrqJZ8RA==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      webpack-sources: ^3
-    peerDependenciesMeta:
-      webpack-sources:
-        optional: true
-    dependencies:
-      acorn: 8.14.0
-      webpack-virtual-modules: 0.6.2
     dev: true
 
   /unplugin@1.16.0:
@@ -7049,10 +7046,10 @@ packages:
     peerDependencies:
       vite: ^2.6.0 || ^3.0.0 || ^4.0.0 || ^5.0.0-0
     dependencies:
-      vite: 5.4.11(@types/node@22.9.4)
+      vite: 5.4.11(@types/node@22.10.0)
     dev: true
 
-  /vite-node@2.1.5(@types/node@22.9.4):
+  /vite-node@2.1.5(@types/node@22.10.0):
     resolution: {integrity: sha512-rd0QIgx74q4S1Rd56XIiL2cYEdyWn13cunYBIuqh9mpmQr7gGS0IxXoP8R6OaZtNQQLyXSWbd4rXKYUbhFpK5w==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -7061,7 +7058,7 @@ packages:
       debug: 4.3.7(supports-color@9.4.0)
       es-module-lexer: 1.5.4
       pathe: 1.1.2
-      vite: 5.4.11(@types/node@22.9.4)
+      vite: 5.4.11(@types/node@22.10.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -7120,7 +7117,7 @@ packages:
       strip-ansi: 6.0.1
       tiny-invariant: 1.3.1
       typescript: 5.7.2
-      vite: 5.4.11(@types/node@22.9.4)
+      vite: 5.4.11(@types/node@22.10.0)
       vscode-languageclient: 7.0.0
       vscode-languageserver: 7.0.0
       vscode-languageserver-textdocument: 1.0.8
@@ -7147,7 +7144,7 @@ packages:
       perfect-debounce: 1.0.0
       picocolors: 1.1.1
       sirv: 2.0.4
-      vite: 5.4.11(@types/node@22.9.4)
+      vite: 5.4.11(@types/node@22.10.0)
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -7167,12 +7164,12 @@ packages:
       '@vue/compiler-dom': 3.5.13
       kolorist: 1.8.0
       magic-string: 0.30.13
-      vite: 5.4.11(@types/node@22.9.4)
+      vite: 5.4.11(@types/node@22.10.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /vite@5.4.11(@types/node@22.9.4):
+  /vite@5.4.11(@types/node@22.10.0):
     resolution: {integrity: sha512-c7jFQRklXua0mTzneGW9QVyxFjUgwcihC4bXEtujIo2ouWCe1Ajt/amn2PCxYnhYfd5k09JX3SB7OYWFKYqj8Q==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -7203,7 +7200,7 @@ packages:
       terser:
         optional: true
     dependencies:
-      '@types/node': 22.9.4
+      '@types/node': 22.10.0
       esbuild: 0.21.5
       postcss: 8.4.49
       rollup: 4.24.4


### PR DESCRIPTION
Dark mode implementation:

* [`app/app.vue`](diffhunk://#diff-8ff0109ae5a1326cff38d204224965a37eeca81598b1a988d577265564316985R129-R139): Added dark mode styles for the body and anchor tags.
* [`app/components/AppHeader.vue`](diffhunk://#diff-0ecff9b7f0a79b79210c118a5437418d5d9e25351ea57b5229c4933baac7d73aR3-R11): Introduced a toggle switch for dark mode using a Vue `ref` and updated the header styles. [[1]](diffhunk://#diff-0ecff9b7f0a79b79210c118a5437418d5d9e25351ea57b5229c4933baac7d73aR3-R11) [[2]](diffhunk://#diff-0ecff9b7f0a79b79210c118a5437418d5d9e25351ea57b5229c4933baac7d73aR53-R60)
* [`app/components/ItemListNav.vue`](diffhunk://#diff-9ef3ed4ae4b6b010e969722da137b7fe9420927b95c713f44b6d1663942c4447R62-R81): Added dark mode styles for the navigation and list items.
* [`app/components/PostComment.vue`](diffhunk://#diff-b7dc7326b768704cbe50bb21ad09e009632c660ccc8aea842a3c53b1485cd3fbR106-R145): Implemented dark mode styles for comments, including nested elements like links and preformatted text.
* [`app/components/PostItem.vue`](diffhunk://#diff-162c2416f69a878e4c69bd31b6ee023082ef9927369eb0a663742ed5527edbb8R89-R111): Added dark mode styles for post items, including the score and metadata.
* `app/pages/[feed]/[page].vue`: Added dark mode styles for the news list. ([app/pages/[feed]/[page].vueR142-R147](diffhunk://#diff-b511a49f15c0070c5a9f1b5aa67ef543d1c2a43632e9aa01f7bedfdae5012d93R142-R147))
* `app/pages/item/[id].vue`: Implemented dark mode styles for the item view header and comments. ([app/pages/item/[id].vueR126-R151](diffhunk://#diff-79e0026bf1a6f351f3880bd69e8f115b42dd4ca65ad3ef02a59fa63038ef6ec6R126-R151))
* `app/pages/user/[id].vue`: Added dark mode styles for the user view page. ([app/pages/user/[id].vueR75-R97](diffhunk://#diff-ccb65611298644d0f60e0d0b3e5fd4a14ec3096511b3e49e4d72221de2b74f63R75-R97))

Dependency updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L26-R29): Updated several development dependencies including `@nuxt/eslint`, `@nuxt/eslint-config`, and `@types/node`.
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL12-R28): Updated versions for multiple packages such as `@clack/core`, `@clack/prompts`, `@nuxt/eslint`, and `@nuxt/eslint-config`. Removed `webpack-sources` references. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL12-R28) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL376-L391) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1157-L1165) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1176-L1181) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1239-R1235) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1250-R1249) [[7]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1263-R1275) [[8]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1289-R1298) [[9]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1315-R1313) [[10]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1327-R1322) [[11]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1338) [[12]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1369) [[13]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1394-L1400) [[14]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1424) [[15]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1448) [[16]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1477-R1469) [[17]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1516-R1506) [[18]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1542) [[19]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1585)